### PR TITLE
Fix thesis kind staying editable

### DIFF
--- a/Ref.Windows/MainWindow.xaml
+++ b/Ref.Windows/MainWindow.xaml
@@ -191,6 +191,7 @@
                 <Grid.Resources>
                     <xaml:AlwaysVisibleConverter x:Key="MakeVisible" />
                     <xaml:EnumIntConverter x:Key="EnumIntConverter" />
+                    <xaml:FlipBoolConverter x:Key="FlipConverter" />
                 </Grid.Resources>
 
                 <!-- Only some of these are visible, depending on whether the property is available. -->
@@ -282,7 +283,8 @@
                 <TextBlock Text="Thesis kind" Visibility="{Binding Kind, Converter={StaticResource MakeVisible}, FallbackValue=Collapsed}"
                            Grid.Row="14" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,0,4" />
                 <ComboBox Visibility="{Binding Kind, Converter={StaticResource MakeVisible}, FallbackValue=Collapsed}"
-                         SelectedIndex="{Binding Kind, Converter={StaticResource EnumIntConverter}}" IsReadOnly="{Binding IsReadOnly}"
+                         SelectedIndex="{Binding Kind, Converter={StaticResource EnumIntConverter}}"
+                          IsEnabled="{Binding IsReadOnly, Converter={StaticResource FlipConverter}}"
                          Grid.Row="14" Grid.Column="2" FontSize="14" Margin="4,0,0,4">
                     <ComboBoxItem>PhD Thesis</ComboBoxItem>
                     <ComboBoxItem>Licentiate Thesis</ComboBoxItem>

--- a/Ref.Windows/Ref.Windows.csproj
+++ b/Ref.Windows/Ref.Windows.csproj
@@ -74,6 +74,7 @@
     <Compile Include="ViewModels\PageViewModel.cs" />
     <Compile Include="ViewModels\PublicationViewModelBase.cs" />
     <Compile Include="ViewModels\ViewModelBase.cs" />
+    <Compile Include="Xaml\FlipBoolConverter.cs" />
     <Compile Include="Xaml\EnumIntConverter.cs" />
     <Compile Include="Xaml\EntryTitleConverter.cs" />
     <Compile Include="Xaml\PageSortConverter.cs" />

--- a/Ref.Windows/Xaml/FlipBoolConverter.cs
+++ b/Ref.Windows/Xaml/FlipBoolConverter.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace Polsys.Ref.Xaml
+{
+    /// <summary>
+    /// Put in a bool, get its inverse back.
+    /// Put in something else, get an exception.
+    /// </summary>
+    /// <remarks>
+    /// Because IsReadOnly does not prevent combo box selection, which can be prevented with IsEnabled,
+    /// which is of course the opposite of IsReadOnly.
+    /// </remarks>
+    public class FlipBoolConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return !(bool)value;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #21.

`IsReadOnly` does not prevent selection on combo boxes. This commit changes it to use `IsEnabled`.

Of course doing that requires another converter. I'm kind of sick of these trivial converters. Maybe I'm just doing it wrong?